### PR TITLE
Fix for invalid YAML syntax

### DIFF
--- a/lib/ting/data/rules.yaml
+++ b/lib/ting/data/rules.yaml
@@ -1,24 +1,27 @@
-hanyu: - match: (j|q|x)ü
-         subst: \1u
-wadegiles: - match: pie\Z
-             subst: pieh
-           - match: (ts|ch)`eh
-             subst: \1`e
-           - match: ts`ih
-             subst: tz`u
-           - match: (k|k`|h)e\Z
-             subst: \1o
-           - match: (k|k`)ui\Z
-             subst: \1uei
-           - match: (sh|ch)o\Z
-             subst: \1e
-           - match: (ch|ch`|ts`|t|t`|l|n|j|s)uo
-             subst: \1o
-           - match: tsih
-             subst: tzu
-           - match: sih
-             subst: ssu
-tongyong: - match: feng
-            subst: fong
+hanyu: 
+  - match: (j|q|x)ü
+    subst: \1u
+wadegiles: 
+  - match: pie\Z
+    subst: pieh
+  - match: (ts|ch)`eh
+    subst: \1`e
+  - match: ts`ih
+    subst: tz`u
+  - match: (k|k`|h)e\Z
+    subst: \1o
+  - match: (k|k`)ui\Z
+    subst: \1uei
+  - match: (sh|ch)o\Z
+    subst: \1e
+  - match: (ch|ch`|ts`|t|t`|l|n|j|s)uo
+    subst: \1o
+  - match: tsih
+    subst: tzu
+  - match: sih
+    subst: ssu
+tongyong: 
+  - match: feng
+    subst: fong
 
           


### PR DESCRIPTION
Encountered an issue installing the gem from master branch, with the error: 

psych.rb:148:in `parse': couldn't parse YAML at line 1 column 7 (Psych::SyntaxError)

After a bit of research, looks like YAML parsers may have gotten stricter. Fixed the offending YAML file (rules.yaml), and it seems to be working now. Tests still passing, short of one that was broken before.
