### PR TITLE
Fix parsing in Ting.pretty_tones/.bpmf helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.1
-  - 2.2.5
-  - 2.3.4
-  - 2.4.2
-  # - jruby
+  - ruby-2.0.0
+  - ruby-2.1.1
+  - ruby-2.2.5
+  - ruby-2.3.4
+  - ruby-2.4.2
   - ruby-head
+  - jruby-9.1.9.0
   - jruby-head
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Generate IPA
    # => "iou˧˩˧ pʰeŋ˧˥ ts˥˩ yɛn˧˥ faŋ˥˥ lai˧˥"
 ````
 
-Since this is such a common use case, a convenience method to add diacritics to pinyin.
+Since this is such a common use case, a convenience method exists to add diacritics to pinyin.
 
 ````ruby
    Ting.pretty_tones "wo3 ai4 ni3"
@@ -82,11 +82,13 @@ Since this is such a common use case, a convenience method to add diacritics to 
 ````
 
 Note that syllables need to be separated by spaces, feeding "peng2you3" to the parser
-does not work. The `String#pretty_tones` method does handle these things a bit more gracefully.
+does not work. The `Ting.pretty_tones(string)` method does handle these things a bit more gracefully.
 
 If you need to parse input that does not conform, consider using a regexp to scan for valid
-syllables, then feed the syllables to the parser one by one. Have a look at `#pretty_tones` for
-an example of how to do this.
+syllables, then feed the syllables to the parser one by one. Have a look at `Ting.pretty_tones` for
+an example of how to do this, but note that it does not support special cases like erhua
+(wanr2 = wan2 er) or non-standard Pinyin syllables like 嗯/"ń" or 呣／"ḿ" (which appear in the official
+Unicode data and some textbooks).
 
 ## REQUIREMENTS
 

--- a/lib/ting.rb
+++ b/lib/ting.rb
@@ -52,13 +52,13 @@ module Ting
 
 
     def pretty_tones(string)
-      string.gsub('u:','ü').gsub(/[A-Za-züÜ]{1,5}\d/) do |syll|
+      string.gsub('u:','ü').gsub(/[A-Za-züÜ]{1,7}\d?/) do |syll|
         SYLLABLE_CACHE[syll]
       end
     end
 
     def bpmf(string)
-      string.gsub('u:','ü').scan(/[A-Za-züÜ]{1,5}\d/).map do |m|
+      string.gsub('u:','ü').scan(/[A-Za-züÜ]{1,7}\d?/).map do |m|
         Ting.writer(:zhuyin, :marks).(
           Ting.reader(:hanyu, :numbers).(m.downcase)
         )

--- a/spec/ting_spec.rb
+++ b/spec/ting_spec.rb
@@ -5,7 +5,7 @@ describe Ting do
   let(:pinyin)   { 'dao4 ke3 dao4 fei1 chang2 dao4'.force_encoding('UTF-8') }
   let(:bopomofo) { 'ㄉㄠˋ ㄎㄜˇ ㄉㄠˋ ㄈㄟ ㄔㄤˊ ㄉㄠˋ'.force_encoding('UTF-8') }
 
-  it 'should convert from Hany Pinyin to Bopomofo' do
+  it 'should convert from Hanyu Pinyin to Bopomofo' do
     expect(Ting.from(:hanyu, :numbers).to(:zhuyin, :marks).convert(pinyin)).to eq(bopomofo)
   end
 
@@ -15,5 +15,10 @@ describe Ting do
 
   it 'should respect capitalization' do
     expect(Ting.from(:hanyu, :numbers).to(:hanyu, :accents).convert('Bei3 jing1')).to eq('Běi jīng')
+  end
+  
+  it 'should parse syllables correctly' do
+    expect(Ting.pretty_tones('wo3 de peng2you3 hen3 zhuang4')).to eq('wǒ de péngyǒu hěn zhuàng')
+    expect(Ting.bpmf('wo3 de peng2you3 hen3 zhuang4')).to eq('ㄨㄛˇ ㄉㄜ˙ ㄆㄥˊ ㄧㄡˇ ㄏㄣˇ ㄓㄨㄤˋ')
   end
 end


### PR DESCRIPTION
README.md references a `String#pretty_tones` helper which is actually `Ting.pretty_tones`.

While fixing this I've noticed another issue. The syllable parsing regex is accurate enough for `Ting.pretty_tones`, but not for `Ting.bpmf`: It's looking for 1-5 characters, but words like 壯/zhuang need six characters. This leads to conversion bugs in `bpmf`, where only the "huang4" of "zhuang4" is matched, and the whole syllable is replaced by ㄏㄨㄤˋ, not ㄓㄨㄤˋ. I've extended the regexp to 1-7 characters so it could theoretically match "zhuangr", even if Ting does not understand erhua yet.

Also, the tone number was mandatory in the regex, so "wo3 de5 peng3you2" would work, but in "wo3 de peng3you2", the "de" was missing from the bopomofo output. I don't think I've broken anything by making it optional.

I've also added a warning to the README regarding current limitations of the syllable parsing in `pretty_tones`.

Maybe I'll use this branch to look into the JRuby thing as well.