### PR TITLE
Fix parsing of "yángròu", plus other fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ting (0.10.0)
+    ting (0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -239,4 +239,4 @@ DEPENDENCIES
   ting!
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/lib/ting/groundwork.rb
+++ b/lib/ting/groundwork.rb
@@ -111,6 +111,8 @@ module Ting
     alias :to_s :inspect
 
     def ==( other )
+      return false unless other.is_a? Syllable
+
       [ other.initial, other.final, other.tone, other.capitalized ] ==
         [ self.initial, self.final, self.tone, self.capitalized ]
     end

--- a/lib/ting/hanyu_pinyin_parser.rb
+++ b/lib/ting/hanyu_pinyin_parser.rb
@@ -15,7 +15,13 @@ module Ting
     end
 
     def sylls_with_erhua
-      @with_erhua ||= all_syllables.map{|p| p + 'r'}
+      @with_erhua ||= all_syllables.
+                        # We assume that syllables ending in 'r' cannot have additional erhua.
+                        reject {|p| p.end_with?('r')}.
+                        # Don't shadow existing syllables, to avoid parsing "er" as "e" + "er".
+                        reject {|p| all_syllables.include?(p + 'r')}.
+                        # Erhua syllables must be followed by whitespace.
+                        map {|p| p + 'r '}
     end
 
     def pinyin_regexp
@@ -25,7 +31,9 @@ module Ting
     def split_pinyin(pinyin)
       pinyin.scan(pinyin_regexp).flat_map do |syll|
         if sylls_with_erhua.include?(syll) && ! all_syllables.include?(syll)
-          [ syll[0..-2], 'er']
+          # For erhua syllables, cut off the trailing 'r ' string (added in #sylls_with_erhua).
+          # Insert a silent er5 syllable in its place.
+          [ syll[0..-3], 'er']
         else
           [ syll ]
         end
@@ -33,7 +41,13 @@ module Ting
     end
 
     def parse(pinyin)
-      split_pinyin(pinyin).map(&hanyu_reader)
+      # Ting cannot parse uppercase pinyin with accents yet.
+      pinyin = pinyin.downcase
+      # Normalize all whitespace into a single space.
+      pinyin = pinyin.gsub(/[[:space:][:punct:]]/, " ")
+      # Append a space to the string so that the regexp above will match erhua at the end.
+      pinyin += ' '
+      split_pinyin(pinyin).map(&hanyu_reader).flatten
     end
     alias call parse
 

--- a/lib/ting/tones/accents.rb
+++ b/lib/ting/tones/accents.rb
@@ -27,7 +27,7 @@ module Ting
         when /a/
           syll.sub(/a/, tone_glyph(:a,tone))
         when /e/
-          syll.sub(/e/, tone_glyph(:e,tone))
+          syll.sub(/e/, tone_glyph(:e,tone)).sub('v', 'ü')
         when /o/
           syll.sub(/o/, tone_glyph(:o,tone))
         when /(i|u|v)\z/

--- a/spec/hanyu_pinyin_parser_spec.rb
+++ b/spec/hanyu_pinyin_parser_spec.rb
@@ -51,6 +51,13 @@ describe Ting::HanyuPinyinParser do
     ])
   end
 
+  it 'should parse sheng3lve4 correctly' do
+    expect(Ting::HanyuPinyinParser.new.parse("shěnglüè")).to eq([
+      Ting::Syllable.new( Ting::Initial::Shi, Ting::Final::Eng, 3 ),
+      Ting::Syllable.new( Ting::Initial::Le,  Ting::Final::Ue,  4 ),
+    ])
+  end
+
   it 'should parse regardless of apostrophes and weird whitespace' do
     pinyin = "Xī'ān\thǎowánr\tma?\nHǎowánr!"
     expect(Ting::HanyuPinyinParser.new.parse(pinyin).map(&:tone)).to eq([1, 1, 3, 2, 5, 5, 3, 2, 5])

--- a/spec/hanyu_pinyin_parser_spec.rb
+++ b/spec/hanyu_pinyin_parser_spec.rb
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+
+describe Ting::HanyuPinyinParser do
+  it 'should be able to parse boring characters' do
+    pinyin = Ting.pretty_tones "Xi2bie2 de Hai3an4"
+    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+      Ting::Syllable.new( Ting::Initial::Xi,    Ting::Final::I,  2 ),
+      Ting::Syllable.new( Ting::Initial::Bo,    Ting::Final::Ie, 2 ),
+      Ting::Syllable.new( Ting::Initial::De,    Ting::Final::E,  5 ),
+      Ting::Syllable.new( Ting::Initial::He,    Ting::Final::Ai, 3 ),
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::An, 4 ),
+    ])
+  end
+
+  it 'should be able to parse erhua' do
+    pinyin = "wèir Wèir"
+    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Ui, 4 ),
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Er, 5 ),
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Ui, 4 ),
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Er, 5 ),
+    ])
+  end
+
+  it 'should be able to discern erhua from other Ri syllables' do
+    pinyin = Ting.pretty_tones "yang2rou4"
+    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Iang, 2 ),
+      Ting::Syllable.new( Ting::Initial::Ri,    Ting::Final::Ou,   4 ),
+    ])
+
+    pinyin = Ting.pretty_tones "sui1ran2"
+    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+      Ting::Syllable.new( Ting::Initial::Si, Ting::Final::Ui, 1 ),
+      Ting::Syllable.new( Ting::Initial::Ri, Ting::Final::An, 2 ),
+    ])
+  end
+
+  it 'should parse er4 correctly' do
+    expect(Ting::HanyuPinyinParser.new.parse("èr")).to eq([
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Er, 4 ),
+    ])
+  end
+
+  it 'should parse Ou1zhou1 correctly' do
+    pinyin = Ting.pretty_tones("ou1zhou1")
+    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Ou, 1 ),
+      Ting::Syllable.new( Ting::Initial::Zhi,   Ting::Final::Ou, 1 ),
+    ])
+  end
+
+  it 'should parse regardless of apostrophes and weird whitespace' do
+    pinyin = "Xī'ān\thǎowánr\tma?\nHǎowánr!"
+    expect(Ting::HanyuPinyinParser.new.parse(pinyin).map(&:tone)).to eq([1, 1, 3, 2, 5, 5, 3, 2, 5])
+  end
+end

--- a/spec/ting_spec.rb
+++ b/spec/ting_spec.rb
@@ -18,7 +18,7 @@ describe Ting do
   end
   
   it 'should parse syllables correctly' do
-    expect(Ting.pretty_tones('wo3 de peng2you3 hen3 zhuang4')).to eq('wǒ de péngyǒu hěn zhuàng')
-    expect(Ting.bpmf('wo3 de peng2you3 hen3 zhuang4')).to eq('ㄨㄛˇ ㄉㄜ˙ ㄆㄥˊ ㄧㄡˇ ㄏㄣˇ ㄓㄨㄤˋ')
+    expect(Ting.pretty_tones('Wo3 de Ou1zhou1 peng2you3 hen3 zhuang4')).to eq('wǒ de ōuzhōu péngyǒu hěn zhuàng')
+    expect(Ting.bpmf('Wo3 de peng2you3 hen3 zhuang4')).to eq('ㄨㄛˇ ㄉㄜ˙ ㄆㄥˊ ㄧㄡˇ ㄏㄣˇ ㄓㄨㄤˋ')
   end
 end


### PR DESCRIPTION
Hi again! One year later and I'm still using this library :)

* My problem was that `HanyuPinyinParser` parsed "yángròu" incorrectly (yang2, er5, ou4). I have fixed this by requiring erhua to be followed by whitespace. It feels a bit like Perl-era regexp cheating, but it works, and I don't think erhua in the middle of a word is a thing(?).
* `HanyuPinyinParser#parse` returned a nested array before. I found this surprising, and added a call to `flatten`. (Breaking change...)

Plus two unrelated things that came up while writing the specs:

* I have added a check to `Syllable#==` so that it won't break when comparing to e.g. an array.
* ~~`Ting.pretty_tones` now preserves case. I am not sure what the purpose of the `.downcase` was that I removed (optimization?), but I can delete this commit if this breaks anythings.~~ I see now that `accents.rb` relies on lower-case Unicode code points, and I have reverted this change.