### PR TITLE
Parse ambiguous pinyin by using stricter regexp

### DIFF
--- a/spec/hanyu_pinyin_parser_spec.rb
+++ b/spec/hanyu_pinyin_parser_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe Ting::HanyuPinyinParser do
   it 'should be able to parse boring characters' do
-    pinyin = Ting.pretty_tones "Xi2bie2 de Hai3an4"
+    pinyin = "xíbié de hǎi'àn"
     expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
       Ting::Syllable.new( Ting::Initial::Xi,    Ting::Final::I,  2 ),
       Ting::Syllable.new( Ting::Initial::Bo,    Ting::Final::Ie, 2 ),
@@ -37,13 +37,17 @@ describe Ting::HanyuPinyinParser do
     ])
   end
 
-  it 'should parse er4 correctly' do
+  it 'should parse er4 and her2 correctly' do
     expect(Ting::HanyuPinyinParser.new.parse("èr")).to eq([
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Er, 4 ),
     ])
+    expect(Ting::HanyuPinyinParser.new.parse("hér")).to eq([
+      Ting::Syllable.new( Ting::Initial::He,    Ting::Final::E,  2 ),
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Er, 5 ),
+    ])
   end
 
-  it 'should parse Ou1zhou1 correctly' do
+  it 'should parse ou1zhou1 correctly' do
     pinyin = Ting.pretty_tones("ou1zhou1")
     expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Ou, 1 ),
@@ -61,5 +65,31 @@ describe Ting::HanyuPinyinParser do
   it 'should parse regardless of apostrophes and weird whitespace' do
     pinyin = "Xī'ān\thǎowánr\tma?\nHǎowánr!"
     expect(Ting::HanyuPinyinParser.new.parse(pinyin).map(&:tone)).to eq([1, 1, 3, 2, 5, 5, 3, 2, 5])
+  end
+
+  it 'should parse ambiguous syllables based on context' do
+    pinyin = 'gūnánguǎnǚ'
+    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+      Ting::Syllable.new( Ting::Initial::Ge, Ting::Final::U,  1 ),
+      Ting::Syllable.new( Ting::Initial::Ne, Ting::Final::An, 2 ),
+      Ting::Syllable.new( Ting::Initial::Ge, Ting::Final::Ua, 3 ),
+      Ting::Syllable.new( Ting::Initial::Ne, Ting::Final::V,  3 ),
+    ])
+
+    pinyin = 'yángròu'
+    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Iang, 2 ),
+      Ting::Syllable.new( Ting::Initial::Ri,    Ting::Final::Ou,   4 ),
+    ])
+  end
+  
+  it 'cannot parse invalid pinyin (missing apostrophe)' do
+    parser = Ting::HanyuPinyinParser.new
+
+    # Syllables that begin with [aeo] must be prefixed with an apostrophe in the middle of the word.
+    # Ref.: https://en.wikipedia.org/wiki/Pinyin#Pronunciation_of_initials, "Note on the apostrophe"
+    expect { parser.parse('hǎiàn') }.to raise_exception(ArgumentError)
+    expect { parser.parse('gōngānjú') }.to raise_exception(ArgumentError)
+    expect { parser.parse('mòshuǐer') }.to raise_exception(ArgumentError)
   end
 end


### PR DESCRIPTION
This is a simple regexp-based fix for #11. It makes Ting extremely strict about parsing syllables that require an apostrophe, even in cases where humans could unambiguously parse the word (see added specs). It also turns the O(n) algorithm based on `String#scan` into an O(n^2) operation.

But on the upside, it lets Ting parse words correctly that were broken before, and I think that outweighs the downsides; let me know if you disagree. I might update this PR to make it a little more tolerant of broken pinyin later, but I don't want to get too crazy with regexps or parser generators.

Using generative tests is not straightforward right now because `Ting.pretty_tones("hai3an4")` returns "hǎiàn" without the apostrophe right now, but I think this should be its own issue/PR.