### PR TITLE
Make parser more tolerant with regexp lookbehind

### DIFF
--- a/lib/ting/hanyu_pinyin_parser.rb
+++ b/lib/ting/hanyu_pinyin_parser.rb
@@ -20,10 +20,17 @@ module Ting
 
     def pinyin_regexp
       # This will parse a cluster of pinyin, i.e. an uninterrupted string of pinyin characters without punctuation.
-      # In the middle of a cluster, we know that syllables starting in a vowel (like 'an') cannot appear,
-      # because these syllables have to be prefixed with an apostrophe.
-      # Example: "hǎi'àn" must be parsed as two clusters ("hǎi" and "àn"), whereas "gūnánguǎnǚ" is a single cluster.
-      @pinyin_cluster_regexp ||= /\A(#{Regexp.union(all_syllables)})(#{Regexp.union(consonant_syllables)})*(r)?\Z/
+      @pinyin_cluster_regexp ||= /\A
+        # Every syllable can appear at the start of a cluster.
+        (#{Regexp.union(all_syllables)})
+        # However, only syllables starting with a consonant can follow, as syllables starting with a vowel have to
+        # be prefixed with an apostrophe.
+        # Since it is common to omit the apostrophe when there is no ambiguity, also allow syllables starting with
+        # a vowel after all letters except n and g, and after -ong, since -on does not appear at the end of a valid
+        # syllable.
+        (#{Regexp.union(consonant_syllables)}|(?<=[^ng]|[ōóǒòo]ng)#{Regexp.union(all_syllables)})*
+        (r)?
+        \Z/x
     end
 
     def pinyin_separator_regexp

--- a/spec/hanyu_pinyin_parser_spec.rb
+++ b/spec/hanyu_pinyin_parser_spec.rb
@@ -2,9 +2,11 @@
 require 'spec_helper'
 
 describe Ting::HanyuPinyinParser do
+  let(:parser) { Ting::HanyuPinyinParser.new }
+
   it 'should be able to parse boring characters' do
     pinyin = "xíbié de hǎi'àn"
-    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+    expect(parser.parse(pinyin)).to eq([
       Ting::Syllable.new( Ting::Initial::Xi,    Ting::Final::I,  2 ),
       Ting::Syllable.new( Ting::Initial::Bo,    Ting::Final::Ie, 2 ),
       Ting::Syllable.new( Ting::Initial::De,    Ting::Final::E,  5 ),
@@ -15,7 +17,7 @@ describe Ting::HanyuPinyinParser do
 
   it 'should be able to parse erhua' do
     pinyin = "wèir Wèir"
-    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+    expect(parser.parse(pinyin)).to eq([
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Ui, 4 ),
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Er, 5 ),
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Ui, 4 ),
@@ -24,39 +26,39 @@ describe Ting::HanyuPinyinParser do
   end
 
   it 'should be able to discern erhua from other Ri syllables' do
-    pinyin = Ting.pretty_tones "yang2rou4"
-    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+    pinyin = Ting.pretty_tones 'yang2rou4'
+    expect(parser.parse(pinyin)).to eq([
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Iang, 2 ),
       Ting::Syllable.new( Ting::Initial::Ri,    Ting::Final::Ou,   4 ),
     ])
 
-    pinyin = Ting.pretty_tones "sui1ran2"
-    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+    pinyin = Ting.pretty_tones 'sui1ran2'
+    expect(parser.parse(pinyin)).to eq([
       Ting::Syllable.new( Ting::Initial::Si, Ting::Final::Ui, 1 ),
       Ting::Syllable.new( Ting::Initial::Ri, Ting::Final::An, 2 ),
     ])
   end
 
   it 'should parse er4 and her2 correctly' do
-    expect(Ting::HanyuPinyinParser.new.parse("èr")).to eq([
+    expect(parser.parse('èr')).to eq([
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Er, 4 ),
     ])
-    expect(Ting::HanyuPinyinParser.new.parse("hér")).to eq([
+    expect(parser.parse('hér')).to eq([
       Ting::Syllable.new( Ting::Initial::He,    Ting::Final::E,  2 ),
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Er, 5 ),
     ])
   end
 
   it 'should parse ou1zhou1 correctly' do
-    pinyin = Ting.pretty_tones("ou1zhou1")
-    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+    pinyin = Ting.pretty_tones('ou1zhou1')
+    expect(parser.parse(pinyin)).to eq([
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Ou, 1 ),
       Ting::Syllable.new( Ting::Initial::Zhi,   Ting::Final::Ou, 1 ),
     ])
   end
 
   it 'should parse sheng3lve4 correctly' do
-    expect(Ting::HanyuPinyinParser.new.parse("shěnglüè")).to eq([
+    expect(parser.parse('shěnglüè')).to eq([
       Ting::Syllable.new( Ting::Initial::Shi, Ting::Final::Eng, 3 ),
       Ting::Syllable.new( Ting::Initial::Le,  Ting::Final::Ue,  4 ),
     ])
@@ -64,12 +66,12 @@ describe Ting::HanyuPinyinParser do
 
   it 'should parse regardless of apostrophes and weird whitespace' do
     pinyin = "Xī'ān\thǎowánr\tma?\nHǎowánr!"
-    expect(Ting::HanyuPinyinParser.new.parse(pinyin).map(&:tone)).to eq([1, 1, 3, 2, 5, 5, 3, 2, 5])
+    expect(parser.parse(pinyin).map(&:tone)).to eq([1, 1, 3, 2, 5, 5, 3, 2, 5])
   end
 
   it 'should parse ambiguous syllables based on context' do
     pinyin = 'gūnánguǎnǚ'
-    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+    expect(parser.parse(pinyin)).to eq([
       Ting::Syllable.new( Ting::Initial::Ge, Ting::Final::U,  1 ),
       Ting::Syllable.new( Ting::Initial::Ne, Ting::Final::An, 2 ),
       Ting::Syllable.new( Ting::Initial::Ge, Ting::Final::Ua, 3 ),
@@ -77,19 +79,32 @@ describe Ting::HanyuPinyinParser do
     ])
 
     pinyin = 'yángròu'
-    expect(Ting::HanyuPinyinParser.new.parse(pinyin)).to eq([
+    expect(parser.parse(pinyin)).to eq([
       Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Iang, 2 ),
       Ting::Syllable.new( Ting::Initial::Ri,    Ting::Final::Ou,   4 ),
     ])
   end
   
-  it 'cannot parse invalid pinyin (missing apostrophe)' do
-    parser = Ting::HanyuPinyinParser.new
-
+  it 'should parse some invalid pinyin (missing apostrophe)' do
     # Syllables that begin with [aeo] must be prefixed with an apostrophe in the middle of the word.
     # Ref.: https://en.wikipedia.org/wiki/Pinyin#Pronunciation_of_initials, "Note on the apostrophe"
-    expect { parser.parse('hǎiàn') }.to raise_exception(ArgumentError)
-    expect { parser.parse('gōngānjú') }.to raise_exception(ArgumentError)
-    expect { parser.parse('mòshuǐer') }.to raise_exception(ArgumentError)
+    # Still, Ting should be able to parse these syllables if they follow unambiguous characters.
+
+    expect(parser.parse('hǎiàn')).to eq([
+      Ting::Syllable.new( Ting::Initial::He,    Ting::Final::Ai, 3 ),
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::An, 4 ),
+    ])
+
+    expect(parser.parse('mòshuǐer')).to eq([
+      Ting::Syllable.new( Ting::Initial::Mo,    Ting::Final::O,  4 ),
+      Ting::Syllable.new( Ting::Initial::Shi,   Ting::Final::Ui, 3 ),
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::Er, 5 ),
+    ])
+
+    expect(parser.parse('gōngānjú')).to eq([
+      Ting::Syllable.new( Ting::Initial::Ge,    Ting::Final::Ong, 1 ),
+      Ting::Syllable.new( Ting::Initial::Empty, Ting::Final::An,  1 ),
+      Ting::Syllable.new( Ting::Initial::Ji,    Ting::Final::V,   2 ),
+    ])
   end
 end


### PR DESCRIPTION
One more :)

TIL about negative regexp lookbehind, which can be used to allow 'an' after an unambiguous syllable like 'hai'.

This seems to have parsed my slightly imperfect set of pinyin (HSK 1-6 vocab) without a hitch! Finally.