### PR TITLE
Add apostrophes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Changed
+- `Ting.pretty_tones` inserts apostrophes before syllables beginning with a, e, o
+- `Ting::HanyuPinyinParser` is better at splitting up compound words correctly
+
 ## [0.11.0] - released 2017-11-06
 
 ### Changed
 - Make `Ting.pretty_tones` work with bopomofo
-- Correct name of Palladius (Cyrilic transcription)
+- Correct name of Palladius (Cyrillic transcription)
 - Add missing IPA finals
 - Change Palladius transcription of "hui" to хуэй
 

--- a/lib/ting.rb
+++ b/lib/ting.rb
@@ -50,15 +50,30 @@ module Ting
       )
     end
 
+    # The longest syllables are six letters long (chuang, shuang, zhuang).
+    SYLLABLE_REGEXP = /[A-Za-züÜ]{1,6}\d?/
 
     def pretty_tones(string)
-      string.gsub('u:','ü').gsub(/[A-Za-züÜ]{1,7}\d?/) do |syll|
-        SYLLABLE_CACHE[syll]
+      string = string.gsub('u:', 'ü') # (note that this implicitly dups the string)
+      # Scan through the string, replacing syllable by syllable.
+      pos = 0
+      while match = string.match(SYLLABLE_REGEXP, pos)
+        syllable = match[0]
+        replacement = SYLLABLE_CACHE[syllable]
+        match_pos = match.begin(0)
+        # If this syllable starts with a vowel and is preceded by a letter (not whitespace or
+        # control characters), insert an apostrophe before it.
+        if match_pos > 0 && string[match_pos - 1] =~ /[[:alpha:]]/ && syllable =~ /^[AEOaoe]/
+          replacement = "'" + replacement
+        end
+        string[match_pos, syllable.length] = replacement
+        pos = match_pos + replacement.length
       end
+      string
     end
 
     def bpmf(string)
-      string.gsub('u:','ü').scan(/[A-Za-züÜ]{1,7}\d?/).map do |m|
+      string.gsub('u:', 'ü').scan(SYLLABLE_REGEXP).map do |m|
         Ting.writer(:zhuyin, :marks).(
           Ting.reader(:hanyu, :numbers).(m.downcase)
         )

--- a/spec/ting_spec.rb
+++ b/spec/ting_spec.rb
@@ -21,4 +21,15 @@ describe Ting do
     expect(Ting.pretty_tones('Wo3 de Ou1zhou1 peng2you3 hen3 zhuang4')).to eq('wǒ de ōuzhōu péngyǒu hěn zhuàng')
     expect(Ting.bpmf('Wo3 de peng2you3 hen3 zhuang4')).to eq('ㄨㄛˇ ㄉㄜ˙ ㄆㄥˊ ㄧㄡˇ ㄏㄣˇ ㄓㄨㄤˋ')
   end
+
+  it 'should be able to pretty-print simple strings' do
+    expect(Ting.pretty_tones('wo3 ai4 ni3')).to eq('wǒ ài nǐ')
+    expect(Ting.pretty_tones('you3dian3r hao3xiao4')).to eq('yǒudiǎnr hǎoxiào')
+  end
+
+  it 'should insert apostrophes when appropriate' do
+    expect(Ting.pretty_tones('hai3an4')).to eq("hǎi'àn")
+    expect(Ting.pretty_tones('ding4e2')).to eq("dìng'é")
+    expect(Ting.pretty_tones('an5an5an5an5an')).to eq("an'an'an'an'an")
+  end
 end


### PR DESCRIPTION
This extends `Ting.pretty_tones` to add apostrophes where necessary (before syllables starting in `[aeo]`).

The code looks super primitive in how it uses `match(re, pos)` to iterate through the array. I'm not sure if there's a great way to achieve the same thing with plain old `gsub`.

I've also updated the changelog.